### PR TITLE
Corrects custom exposed port via env var

### DIFF
--- a/gocd_prometheus.py
+++ b/gocd_prometheus.py
@@ -19,7 +19,7 @@ urllib3.disable_warnings()
 
 
 GOCD_URL = os.getenv("GOCD_URL")
-EXPOSE_PORT = os.getenv("PROMETHEUS_PORT", 8000)
+EXPOSE_PORT = int(os.getenv("PROMETHEUS_PORT", 8000))
 GOCD_USERNAME = os.getenv("GOCD_USERNAME")
 GOCD_PASSWORD = os.getenv("GOCD_PASSWORD")
 GOCD_SSL_VERIFY = os.getenv("GOCD_SSL_VERIFY", True) in [


### PR DESCRIPTION
Currently setting PROMETHEUS_PORT environment variable raises a TypeError:

```
Traceback (most recent call last):
  File "/usr/local/bin/gocd_prometheus", line 37, in <module>
    start_http_server(EXPOSE_PORT)
  File "/usr/local/lib/python2.7/site-packages/prometheus_client/exposition.py", line 192, in start_http_server
    httpd = _ThreadingSimpleServer((addr, port), CustomMetricsHandler)
  File "/usr/local/lib/python2.7/SocketServer.py", line 420, in __init__
    self.server_bind()
  File "/usr/local/lib/python2.7/BaseHTTPServer.py", line 108, in server_bind
    SocketServer.TCPServer.server_bind(self)
  File "/usr/local/lib/python2.7/SocketServer.py", line 434, in server_bind
    self.socket.bind(self.server_address)
  File "/usr/local/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
TypeError: an integer is required
```